### PR TITLE
corrigindo altura do menu lateral e adicionando margem no final da página

### DIFF
--- a/src/components/menu-icon/style.css
+++ b/src/components/menu-icon/style.css
@@ -1,28 +1,28 @@
 * {
-    margin: 0px;
-    padding: 0px;
-    box-sizing: border-box;
+	margin: 0px;
+	padding: 0px;
+	box-sizing: border-box;
 }
 
 .menu-dashboard {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 4.5rem;
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	gap: 4.5rem;
 
-    background-color: rgba(240, 240, 245, 1);
+	background-color: rgba(240, 240, 245, 1);
 
-    padding: 2.25rem 0;
-    width: 6.75rem;
-    height: 100vh;
+	padding: 2.25rem 0;
+	width: 6.75rem;
+	height: 100%;
 }
 
 .menu-home {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
+	display: flex;
+	flex-direction: column;
+	align-items: center;
 
-    width: 7rem;
-    height: 5.125rem;
-    border-right: 0.125rem solid rgba(218, 1, 117, 1);
+	width: 7rem;
+	height: 5.125rem;
+	border-right: 0.125rem solid rgba(218, 1, 117, 1);
 }

--- a/src/pages/Home/styles.css
+++ b/src/pages/Home/styles.css
@@ -1,10 +1,14 @@
+.content {
+	margin-bottom: 2.5rem;
+}
+
 .dashboard {
-    display: flex;
-    flex-direction: row;
+	display: flex;
+	flex-direction: row;
 }
 
 .tables-dashboard {
-    justify-content: space-between;
-    padding: 1.5rem 0 0 5rem;
-    gap: 1.8125rem
+	justify-content: space-between;
+	padding: 1.5rem 0 0 5rem;
+	gap: 1.8125rem;
 }


### PR DESCRIPTION
Corrigi a altura do menu lateral (menu-icon) pra ficar 100% da altura da página. Também adicionei uma margem na div 'content' do  componente Home pra criar um espaço no final da página.

![home1](https://github.com/LuizLimaDev/front-back-mountain-frontend/assets/109086907/1b776308-4510-4b73-a24d-7d952374b0d7)

![home2](https://github.com/LuizLimaDev/front-back-mountain-frontend/assets/109086907/ef66928e-9c86-4489-800b-c268b19af4cb)
